### PR TITLE
Enhance kmutex implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [![GoDoc](https://godoc.org/github.com/im7mortal/kmutex?status.svg)](https://godoc.org/github.com/im7mortal/kmutex)
 # kmutex
-Sync primitive for golang. Allow block part of resource by unique ID.
+Synchronization primitive that allows locking individual resources by unique ID.
 
-It's not distributed lock.
+This is not a distributed lock.
 
-Check [golang.org/x/sync/singleflight](https://godoc.org/golang.org/x/sync/singleflight) if you wanna reduce number of calls to the same resource. Use kmutex if you want only one caller could use resource at time.
+See [golang.org/x/sync/singleflight](https://godoc.org/golang.org/x/sync/singleflight) if you want to reduce the number of calls to the same resource. Use kmutex if you want only one caller to use a resource at time.
 
-[Kubernetes kmutex](https://godoc.org/k8s.io/utils/keymutex) allow limit total number of calls to resource. Check implementation, it's very straight forward. You would prefer to copy it locally because it also contain kubernetes logger calls.  :heavy_exclamation_mark: That implementation can be cause `significant` delays if you don't know how it works underhood.
+[Kubernetes kmutex](https://godoc.org/k8s.io/utils/keymutex) hashes keys to a fixed set of locks, and is useful if you do not always need a separate lock for each resource.  Take a look at the implementation, it is very straight forward.
 
-[GO PLAYGROUND EXAMPLE](https://play.golang.org/p/B-LBepY9rn)
+[GO PLAYGROUND EXAMPLE](https://play.golang.org/p/TPJPmW_upWO)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/im7mortal/kmutex
+
+go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/im7mortal/kmutex
+module github.com/gammazero/kmutex
 
 go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/gammazero/kmutex
+module github.com/im7mortal/kmutex
 
 go 1.15

--- a/kmutex_test.go
+++ b/kmutex_test.go
@@ -1,77 +1,95 @@
-package kmutex_test
+package kmutex
 
 import (
 	"sync"
 	"testing"
-
-	"github.com/im7mortal/kmutex"
 )
 
-const number  = 100
+// Number of unique resources to access
+const number = 100
+
+func makeIds(count int) []int {
+	ids := make([]int, count)
+	for i := 0; i < count; i++ {
+		ids[i] = i
+	}
+	return ids
+}
 
 func TestKmutex(t *testing.T) {
+	km := New()
+	ids := makeIds(number)
+	resources := make([]int, number)
 	wg := sync.WaitGroup{}
 
-	km := kmutex.New()
-
-	ids := []int{}
-
-	for i := 0; i < number; i++ {
-		ids = append(ids, i)
-	}
-
-	ii := 0
-	for i := 0; i < number * number; i++ {
+	// Start 10n goroutines accessing n resources 10 times each
+	for i := 0; i < 10*number; i++ {
 		wg.Add(1)
-		go func(iii int) {
-			km.Lock(ids[iii])
-			km.Unlock(ids[iii])
+		go func(k int) {
+			for j := 0; j < 10; j++ {
+				km.Lock(ids[k])
+				// read and write resource to check for race
+				resources[k] = resources[k] + 1
+				km.Unlock(ids[k])
+			}
 			wg.Done()
-		}(ii)
-		ii++
-		if ii == number {
-			ii = 0
-		}
+		}(i % len(ids))
 	}
 	wg.Wait()
 }
 
 func TestWithLock(t *testing.T) {
-	wg := sync.WaitGroup{}
 	l := sync.Mutex{}
-	km := kmutex.WithLock(&l)
+	km := WithLock(&l)
+	ids := makeIds(number)
+	resources := make([]int, number)
+	wg := sync.WaitGroup{}
 
-	ids := []int{}
-
-	for i := 0; i < number; i++ {
-		ids = append(ids, i)
-	}
-
-	ii := 0
-	for i := 0; i < number * number; i++ {
+	// Start 10n goroutines accessing n resources 10 times each
+	for i := 0; i < 10*number; i++ {
 		wg.Add(1)
-		go func(iii int) {
-			km.Lock(ids[iii])
-			km.Unlock(ids[iii])
+		go func(k int) {
+			for j := 0; j < 10; j++ {
+				km.Lock(ids[k])
+				// read and write resource to check for race
+				resources[k] = resources[k] + 1
+				km.Unlock(ids[k])
+			}
 			wg.Done()
-		}(ii)
-		ii++
-		if ii == number {
-			ii = 0
-		}
+		}(i % len(ids))
 	}
 	wg.Wait()
 }
 
-
 func TestLockerInterface(t *testing.T) {
-	km := kmutex.New()
-
+	km := New()
 	locker := km.Locker("TEST")
-
 	cond := sync.NewCond(locker)
 
 	if false {
 		cond.Wait()
 	}
+}
+
+func BenchmarkKmutex1000(b *testing.B) {
+	km := New()
+	ids := makeIds(number)
+	resources := make([]int, number)
+	wg := sync.WaitGroup{}
+
+	// Start 1000 goroutines accessing 100 resources N times each
+	b.ResetTimer()
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func(k int) {
+			for j := 0; j < b.N; j++ {
+				km.Lock(ids[k])
+				// read and write resource to check for race
+				resources[k] = resources[k] + 1
+				km.Unlock(ids[k])
+			}
+			wg.Done()
+		}(i % len(ids))
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
- Increased performance by replacing `cond.Broadcast` with `cond.Signal`.  Since only one other goroutine can acquire any individual resource, it is only necessary to wake up one when unlocking.
- Unit tests repeatedly read and write resources to detect any race condition.
- Edited documentation for clarity
- Added benchmark
- Added go.mod