### PR TITLE
Fix use of Cond.Signal to avoid deadlock

### DIFF
--- a/kmutex.go
+++ b/kmutex.go
@@ -11,27 +11,37 @@ import "sync"
 
 // Can be locked by unique ID
 type Kmutex struct {
-	c *sync.Cond
 	l sync.Locker
-	s map[interface{}]struct{}
+	s map[interface{}]*klock
+}
+
+// klock is a per-key lock that conatins a sync.Cond to signal another
+// goroutine that the lock is available, a reference count of the number of
+// goroutines waiting for and using the lock, and a boolean to check if the
+// lock is already unlocked.
+//
+// It is necessary to use a separate condition variable for each key to ensure
+// that only a goroutine that is waiting for that key is awakened.
+type klock struct {
+	cond   *sync.Cond
+	locked bool
+	ref    uint64
 }
 
 // Create new Kmutex
 func New() *Kmutex {
 	l := sync.Mutex{}
 	return &Kmutex{
-		c: sync.NewCond(&l),
 		l: &l,
-		s: make(map[interface{}]struct{}),
+		s: make(map[interface{}]*klock),
 	}
 }
 
 // Create new Kmutex with user provided lock
 func WithLock(l sync.Locker) *Kmutex {
 	return &Kmutex{
-		c: sync.NewCond(l),
 		l: l,
-		s: make(map[interface{}]struct{}),
+		s: make(map[interface{}]*klock),
 	}
 }
 
@@ -39,24 +49,41 @@ func WithLock(l sync.Locker) *Kmutex {
 func (km *Kmutex) Unlock(key interface{}) {
 	km.l.Lock()
 	defer km.l.Unlock()
-	delete(km.s, key)
-	km.c.Signal()
+	kl, ok := km.s[key]
+	if !ok || !kl.locked {
+		panic("unlock of unlocked kmutex")
+	}
+	kl.ref--
+	if kl.ref == 0 {
+		delete(km.s, key)
+		return
+	}
+	kl.locked = false
+	kl.cond.Signal()
 }
 
 // Lock Kmutex by unique ID
 func (km *Kmutex) Lock(key interface{}) {
 	km.l.Lock()
 	defer km.l.Unlock()
-	for km.locked(key) {
-		km.c.Wait()
-	}
-	km.s[key] = struct{}{}
-	return
-}
+	for {
+		kl, ok := km.s[key]
+		if !ok {
+			km.s[key] = &klock{
+				cond:   sync.NewCond(km.l),
+				locked: true,
+				ref:    1,
+			}
+			return
+		}
 
-func (km *Kmutex) locked(key interface{}) bool {
-	_, ok := km.s[key]
-	return ok
+		kl.ref++
+		kl.cond.Wait()
+		// No need to check if locked, since signal only given on unlock and
+		// only delivered to one goroutine.
+		kl.locked = true
+		return
+	}
 }
 
 // satisfy sync.Locker interface

--- a/kmutex_test.go
+++ b/kmutex_test.go
@@ -3,6 +3,7 @@ package kmutex
 import (
 	"sync"
 	"testing"
+	"time"
 )
 
 // Number of unique resources to access
@@ -22,19 +23,52 @@ func TestKmutex(t *testing.T) {
 	resources := make([]int, number)
 	wg := sync.WaitGroup{}
 
+	lc := make(chan int)
+	uc := make(chan int)
 	// Start 10n goroutines accessing n resources 10 times each
 	for i := 0; i < 10*number; i++ {
 		wg.Add(1)
 		go func(k int) {
 			for j := 0; j < 10; j++ {
+				lc <- k
 				km.Lock(ids[k])
 				// read and write resource to check for race
 				resources[k] = resources[k] + 1
 				km.Unlock(ids[k])
+				uc <- k
 			}
 			wg.Done()
 		}(i % len(ids))
 	}
+
+	to := time.After(time.Second)
+	counts := make(map[int]int)
+	var lCount, ulCount int
+loop:
+	for {
+		select {
+		case k := <-lc:
+			counts[k] = counts[k] + 1
+			lCount++
+		case k := <-uc:
+			counts[k] = counts[k] - 1
+			ulCount++
+		case <-to:
+			t.Fatal("timed out waiting for results")
+			break loop
+		}
+		expectCount := 100 * number
+		if lCount == expectCount && ulCount == expectCount {
+			// Have all results
+			break
+		}
+	}
+	for k, c := range counts {
+		if c != 0 {
+			t.Errorf("Key %d count != 0: %d\n", k, c)
+		}
+	}
+
 	wg.Wait()
 }
 
@@ -76,6 +110,72 @@ func TestLockerInterface(t *testing.T) {
 
 	if false {
 		cond.Wait()
+	}
+}
+
+func TestCondDeadlock(t *testing.T) {
+	l := sync.Mutex{}
+	km := WithLock(&l)
+	ids := makeIds(10)
+
+	timeout := time.NewTimer(time.Second)
+	defer timeout.Stop()
+
+	for checks := 0; checks < 5; checks++ {
+		done := make(chan struct{})
+		go func() {
+			for i := 0; i < len(ids); i++ {
+				km.Lock(ids[i])
+			}
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-timeout.C:
+			t.Fatal("timeout while locking all locks")
+		}
+
+		var wg, wgReady sync.WaitGroup
+		unlocked := make(chan int, len(ids))
+		for i := 0; i < len(ids); i++ {
+			wg.Add(1)
+			wgReady.Add(1)
+			go func(k int) {
+				wgReady.Done()
+				km.Lock(ids[k])
+				unlocked <- k
+				wg.Done()
+			}(i)
+		}
+		wgReady.Wait()
+
+		km.Unlock(ids[0])
+		select {
+		case u := <-unlocked:
+			if u != 0 {
+				t.Fatal("unlocked wrong key, expected 0 but got", u)
+			}
+		case <-timeout.C:
+			t.Fatal("timed out waiting for ids[0] to unlock")
+		}
+
+		if !timeout.Stop() {
+			<-timeout.C
+		}
+
+		for i := 1; i < len(ids); i++ {
+			km.Unlock(ids[i])
+			u := <-unlocked
+			if u != ids[i] {
+				t.Fatal("unlocked wrong key, expected", ids[i], "got", u)
+			}
+		}
+		for i := 0; i < len(ids); i++ {
+			km.Unlock(ids[i])
+		}
+		wg.Wait()
+		timeout.Reset(time.Second)
 	}
 }
 


### PR DESCRIPTION
Previously, unlocking a key could signal any of the waiting goroutines, even if they were waiting on a different key than the one being unlocked.  This can cause a deadlock as the goroutines waiting on a particular key may never see it unlocked.  This is fixed by using a separate condition variable for each key, ensuring that only a goroutine that is waiting for that key is awakened.

Using `Cond.Broadcast()` is not an option as that will cause a storm of waiters all waking up when only one needs to awaken.
