### PR TITLE
Add waited return var to Lock

### DIFF
--- a/kmutex.go
+++ b/kmutex.go
@@ -62,8 +62,8 @@ func (km *Kmutex) Unlock(key interface{}) {
 	kl.cond.Signal()
 }
 
-// Lock Kmutex by unique ID
-func (km *Kmutex) Lock(key interface{}) {
+// Lock Kmutex by unique ID. Returns if waited for an Unlock.
+func (km *Kmutex) Lock(key interface{}) (waited bool) {
 	km.l.Lock()
 	defer km.l.Unlock()
 	for {
@@ -74,7 +74,7 @@ func (km *Kmutex) Lock(key interface{}) {
 				locked: true,
 				ref:    1,
 			}
-			return
+			return false
 		}
 
 		kl.ref++
@@ -82,7 +82,7 @@ func (km *Kmutex) Lock(key interface{}) {
 		// No need to check if locked, since signal only given on unlock and
 		// only delivered to one goroutine.
 		kl.locked = true
-		return
+		return true
 	}
 }
 

--- a/kmutex_test.go
+++ b/kmutex_test.go
@@ -179,6 +179,28 @@ func TestCondDeadlock(t *testing.T) {
 	}
 }
 
+func TestWaited(t *testing.T) {
+	km := New()
+
+	km.Lock(2) // in case a different key affects
+
+	if km.Lock(1) {
+		t.Fatal("expected not to wait")
+	}
+	time.AfterFunc(100*time.Millisecond, func() {
+		km.Unlock(1)
+	})
+
+	if !km.Lock(1) {
+		t.Fatal("expected to wait")
+	}
+	km.Unlock(1)
+
+	if km.Lock(1) {
+		t.Fatal("expected not to wait")
+	}
+}
+
 func BenchmarkKmutex1000(b *testing.B) {
 	km := New()
 	ids := makeIds(number)


### PR DESCRIPTION
In cases where you might have a GetThing() that concurrently does:
```
Check cache for k
If hit, return the val
If miss,
     do expensive work
     set in cache
     return the cached val
```

Using this pkg to put a Lock around the miss part can make sure we don't repeat expensive work from concurrent calls both seeing a miss. With the Lock though you'd want to check after the lock is entered if we are already cached since we could have just waited on a concurrent caller that set the cache.

So it would be:
```
Check cache for k
If hit, return the val
If miss,
     Lock(k)
     defer Lock(k)
     Check cache for k
        if hit, return the val
     do expensive work
     set in cache
     return the cached val
```
The added `waited` return var can allow a skipping of the extra check if `waited=false`.